### PR TITLE
fix: resolve release lint and type checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   "scripts": {
     "dev": "bun ./esbuild.config.mjs",
     "build": "bun ./esbuild.config.mjs production",
-    "lint": "bunx biome lint src version-bump.ts",
-    "format": "bunx biome format src version-bump.ts --write",
-    "check": "bunx @biomejs/biome check --write src version-bump.ts && bun run type-check",
+    "lint": "biome lint src version-bump.ts",
+    "format": "biome format src version-bump.ts --write",
+    "check": "biome check --write src version-bump.ts && bun run type-check",
     "type-check": "bun tsc --noEmit",
     "version": "bun ./version-bump.ts && git add manifest.json versions.json",
     "semantic-release": "semantic-release"

--- a/src/actions/EditAction.ts
+++ b/src/actions/EditAction.ts
@@ -1,7 +1,9 @@
 import { renderTemplate } from "@/TemplateEngine";
+import { DiffReviewView } from "@/components/DiffReviewView";
 import { logger } from "@/logging";
 import { removeWhitespace } from "@/utils";
 import { type Editor, MarkdownView, type TFile } from "obsidian";
+import type { WorkspaceLeaf } from "obsidian";
 import type {
 	ChatCompletion,
 	ChatCompletionMessageParam,
@@ -9,8 +11,6 @@ import type {
 import { merge } from "three-way-merge";
 import { z } from "zod";
 import { Action, type ActionContext } from "./Action";
-import { DiffReviewView } from "@/components/DiffReviewView";
-import type { WorkspaceLeaf } from "obsidian";
 
 const prompt = removeWhitespace(`
     You are an AI assistant tasked with updating a file's content based on specific instructions. This task requires precision and attention to detail to ensure that only the relevant parts of the file are modified while maintaining the integrity of the rest of the content.

--- a/src/actions/NoopAction.ts
+++ b/src/actions/NoopAction.ts
@@ -5,7 +5,7 @@ import { Action, type ActionContext } from "./Action";
 export class NoopAction extends Action<typeof NoopAction.inputSchema> {
 	readonly description =
 		"This action does nothing and is used when no specific action is required.";
-	readonly usesLLM = false;
+	override readonly usesLLM = false;
 
 	static inputSchema = z.object({});
 

--- a/src/actions/QuickAddAction.ts
+++ b/src/actions/QuickAddAction.ts
@@ -1,12 +1,8 @@
 import { logger } from "@/logging";
 import { removeWhitespace } from "@/utils";
+import { type QuickAddChoice, flattenQuickAddChoices } from "@/utils/quickadd";
 import { z } from "zod";
 import { Action, type ActionContext } from "./Action";
-import {
-	flattenQuickAddChoices,
-	type QuickAddChoice,
-	type QuickAddPlugin,
-} from "@/utils/quickadd";
 
 // Utility: Extract variable names from a string (supports {{VALUE}} and {{VALUE:varName}})
 function extractVariablesFromString(str: string): Set<string> {
@@ -77,7 +73,7 @@ export class QuickAddAction extends Action<typeof QuickAddAction.inputSchema> {
 		context: ActionContext,
 	): Promise<void> {
 		const { app, results } = context;
-		const quickAdd = app.plugins.plugins.quickadd as QuickAddPlugin | undefined;
+		const quickAdd = app.plugins.plugins.quickadd;
 		if (!quickAdd || !quickAdd.api || !quickAdd.settings) {
 			logger.error("QuickAdd plugin is not installed or enabled.");
 			results.set(this.id, {

--- a/src/actions/TranscribeAction.ts
+++ b/src/actions/TranscribeAction.ts
@@ -11,7 +11,7 @@ export class TranscribeAction extends Action<
 	typeof TranscribeAction.inputSchema
 > {
 	readonly description = "Format transcribed audio to be more readable.";
-	readonly usesLLM = false;
+	override readonly usesLLM = false;
 
 	static inputSchema = z.object({
 		transcription: z

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1,6 +1,9 @@
 import type { EditorState } from "@/actions/Action";
 import type AuralitePlugin from "@/main";
 import { removeWhitespace } from "@/utils";
+import { flattenQuickAddChoices } from "@/utils/quickadd";
+import { generateRequestId, getOrCreateSessionId } from "@/utils/session";
+import { type TelemetryContext, withTelemetry } from "@/utils/withTelemetry";
 import type Instructor from "@instructor-ai/instructor";
 import type OpenAI from "openai";
 import type { ClientOptions } from "openai";
@@ -12,9 +15,6 @@ import { hasUsage, isActionResponse } from "./api_types";
 import { logger } from "./logging";
 import { telemetry } from "./telemetry";
 import { TypedEvents } from "./types/TypedEvents";
-import { withTelemetry, type TelemetryContext } from "@/utils/withTelemetry";
-import { getOrCreateSessionId, generateRequestId } from "@/utils/session";
-import { flattenQuickAddChoices, type QuickAddPlugin } from "@/utils/quickadd";
 
 interface AIManagerEvents {
 	processingStarted: () => void;
@@ -654,8 +654,7 @@ export class AIManager extends TypedEvents<AIManagerEvents> {
 
 function buildQuickAddPromptSection(plugin: AuralitePlugin): string {
 	const quickAddAction = plugin.actionManager.getAction("quickadd");
-	const quickAddPlugin = (plugin.app as import("obsidian").App).plugins?.plugins
-		?.quickadd as QuickAddPlugin | undefined;
+	const quickAddPlugin = plugin.app.plugins?.plugins?.quickadd;
 	if (!quickAddAction || !quickAddPlugin?.settings?.choices) return "";
 	const allQuickAddChoices = flattenQuickAddChoices(
 		quickAddPlugin.settings.choices,

--- a/src/components/DiffReviewView.ts
+++ b/src/components/DiffReviewView.ts
@@ -1,8 +1,8 @@
-import { ItemView, MarkdownRenderer, setIcon } from "obsidian";
-import { EditorView } from "@codemirror/view";
+import { basicSetup } from "@codemirror/basic-setup";
 import { markdown } from "@codemirror/lang-markdown";
 import { MergeView } from "@codemirror/merge";
-import { basicSetup } from "@codemirror/basic-setup";
+import { EditorView } from "@codemirror/view";
+import { ItemView, MarkdownRenderer, setIcon } from "obsidian";
 import type { WorkspaceLeaf as ObsidianWorkspaceLeaf } from "obsidian";
 
 export const DIFF_REVIEW_VIEW_TYPE = "auralite-diff-review-view";

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { ActionManager } from "./actions/ActionManager";
 import { CreateNoteAction } from "./actions/CreateNoteAction";
 import { EditAction } from "./actions/EditAction";
 import { NoopAction } from "./actions/NoopAction";
+import { QuickAddAction } from "./actions/QuickAddAction";
 import { TranscribeAction } from "./actions/TranscribeAction";
 import { WriteAction } from "./actions/WriteAction";
 import { AIManager } from "./ai";
@@ -26,7 +27,6 @@ import { logger } from "./logging";
 import { AssistantTask } from "./tasks/AssistantTask";
 import { TranscribeTask } from "./tasks/TranscribeTask";
 import { telemetry } from "./telemetry";
-import { QuickAddAction } from "./actions/QuickAddAction";
 
 declare const __IS_DEV__: boolean;
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -332,7 +332,7 @@
 	background: var(--background-secondary-alt, var(--background-secondary));
 	border-radius: 12px;
 	border: 1px solid var(--background-modifier-border);
-	box-shadow: 0 1px 2px rgba(0,0,0,0.02);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
 }
 .auralite-settings-section h3 {
 	margin-top: 0;

--- a/src/tasks/AssistantTask.ts
+++ b/src/tasks/AssistantTask.ts
@@ -4,9 +4,6 @@ import { WaveformVisualizer } from "@/components/WaveformVisualizer";
 import { logger } from "@/logging";
 import { Task } from "@/tasks/Task";
 import { delay } from "@/utils";
-import { EditActionStatus } from "@/actions/EditAction";
-import type { EditActionResult } from "@/actions/EditAction";
-import type { ActionContext } from "@/actions/Action";
 
 declare const __IS_DEV__: boolean;
 
@@ -146,24 +143,6 @@ export class AssistantTask extends Task {
 		} finally {
 			await delay(3000);
 			this.finish();
-		}
-	}
-
-	private handleEditResult(context: ActionContext) {
-		const result = context.results?.get("edit") as EditActionResult | undefined;
-		if (!result) return;
-		switch (result.status) {
-			case EditActionStatus.REJECTED:
-				this.floatingBar?.setStatus("Edit discarded. No changes were made.");
-				break;
-			case EditActionStatus.APPLIED:
-				this.floatingBar?.setStatus("Edit applied successfully.");
-				break;
-			case EditActionStatus.ERROR:
-				this.floatingBar?.setStatus(
-					result.error || "An error occurred while applying the edit.",
-				);
-				break;
 		}
 	}
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -106,7 +106,9 @@ export class Telemetry {
 	private maxLogSize = 1000; // Maximum number of records to keep
 
 	// Pricing per 1000 tokens in USD (updated 2025-03-16)
-	private modelPricing: Record<string, ModelPricing> = {
+	private modelPricing: Record<string, ModelPricing> & {
+		default: ModelPricing;
+	} = {
 		"gpt-4.1": { prompt: 0.002, completion: 0.008 },
 		"gpt-4.1-mini": { prompt: 0.0002, completion: 0.0008 },
 		"gpt-4.1-nano": { prompt: 0.0001, completion: 0.0004 },
@@ -130,7 +132,6 @@ export class Telemetry {
 
 	// Get default pricing for unknown models
 	private getDefaultPricing(): ModelPricing {
-		// Using bracket notation to avoid TypeScript index signature error
 		return this.modelPricing.default;
 	}
 

--- a/src/types/obsidian.d.ts
+++ b/src/types/obsidian.d.ts
@@ -1,9 +1,13 @@
 import "obsidian";
+import type { QuickAddPlugin } from "../utils/quickadd";
 
 declare module "obsidian" {
 	interface App {
 		plugins: {
-            plugins: any;
+			plugins: {
+				quickadd?: QuickAddPlugin;
+				[pluginId: string]: unknown;
+			};
 			disablePlugin(id: string): Promise<void>;
 			enablePlugin(id: string): Promise<void>;
 		};

--- a/src/utils/withTelemetry.ts
+++ b/src/utils/withTelemetry.ts
@@ -1,5 +1,4 @@
 import { telemetry } from "@/telemetry";
-import type { TokenUsage } from "@/telemetry";
 
 export interface TelemetryContext {
 	sessionId: string;
@@ -24,15 +23,13 @@ export async function withTelemetry<T>(
 		getPayload(),
 	);
 	try {
-		const result = await fn(requestId, context);
-		telemetry.finishRecording(
-			requestId,
-			{ success: true, estimated: false },
-			context,
-		);
-		return result;
+		return await fn(requestId, context);
 	} catch (error) {
-		telemetry.finishRecording(requestId, { error, estimated: false }, context);
+		telemetry.finishRecording(requestId, {
+			promptTokens: 0,
+			completionTokens: 0,
+			error: error instanceof Error ? error : new Error(String(error)),
+		});
 		throw error;
 	}
 }


### PR DESCRIPTION
## Summary
- Type the Obsidian plugin registry without `any` so release lint passes.
- Align Biome scripts with the installed local CLI to avoid CI pulling an incompatible version.
- Clean up TypeScript and Biome warnings surfaced by the release check.

## Test plan
- `bun run lint`
- `bun run check`
- `bun run build`


Made with [Cursor](https://cursor.com)