### PR TITLE
feat(transcription): save audio attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 **Command**: `Transcribe`
 - Speak your thoughts and get formatted text at your cursor
 - Automatic punctuation and paragraph breaks
+- Optionally save the original recording as a vault attachment embedded after the transcript
 - Supports multiple languages and accents
 
 ### AI Assistant

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "dev": "bun ./esbuild.config.mjs",
     "build": "bun ./esbuild.config.mjs production",
+    "test": "bun test",
     "lint": "biome lint src version-bump.ts",
     "format": "biome format src version-bump.ts --write",
     "check": "biome check --write src version-bump.ts && bun run type-check",

--- a/src/AudioRecorder.ts
+++ b/src/AudioRecorder.ts
@@ -3,7 +3,7 @@ import { TypedEvents } from "./types/TypedEvents";
 
 interface AudioRecorderEvents {
 	dataAvailable: (data: Blob) => void;
-	recordingComplete: (data: { buffer: ArrayBuffer; mimeType: string }) => void;
+	recordingComplete: (data: AudioRecording) => void;
 	recordingStarted: () => void;
 	recordingStopped: () => void;
 	recordingCancelled: (error: Error) => void;
@@ -11,16 +11,16 @@ interface AudioRecorderEvents {
 	error: (error: unknown) => void;
 }
 
+export interface AudioRecording {
+	buffer: ArrayBuffer;
+	fileExtension: string;
+}
+
 export class AudioRecorder extends TypedEvents<AudioRecorderEvents> {
 	private mediaRecorder: MediaRecorder | null = null;
 	private audioChunks: Blob[] = [];
-	private recordingPromise: Promise<{
-		buffer: ArrayBuffer;
-		mimeType: string;
-	}> | null = null;
-	private resolveRecording:
-		| ((value: { buffer: ArrayBuffer; mimeType: string }) => void)
-		| null = null;
+	private recordingPromise: Promise<AudioRecording> | null = null;
+	private resolveRecording: ((value: AudioRecording) => void) | null = null;
 	private rejectRecording: ((reason: unknown) => void) | null = null;
 	private audioContext: AudioContext | null = null;
 	private analyser: AnalyserNode | null = null;
@@ -48,12 +48,12 @@ export class AudioRecorder extends TypedEvents<AudioRecorderEvents> {
 
 	private handleStop = () => {
 		const fullMimeType = this.mediaRecorder?.mimeType || "audio/webm";
-		const mimeType = this.getMimeTypeExtension(fullMimeType);
+		const fileExtension = this.getMimeTypeExtension(fullMimeType);
 		const audioBlob = new Blob(this.audioChunks, { type: fullMimeType });
 		audioBlob.arrayBuffer().then((buffer) => {
 			if (this.resolveRecording) {
-				this.resolveRecording({ buffer, mimeType });
-				this.trigger("recordingComplete", { buffer, mimeType });
+				this.resolveRecording({ buffer, fileExtension });
+				this.trigger("recordingComplete", { buffer, fileExtension });
 			}
 		});
 		this.trigger("recordingStopped");
@@ -125,7 +125,7 @@ export class AudioRecorder extends TypedEvents<AudioRecorderEvents> {
 		}
 	}
 
-	stop(): Promise<{ buffer: ArrayBuffer; mimeType: string }> {
+	stop(): Promise<AudioRecording> {
 		if (!this.mediaRecorder || this.mediaRecorder.state !== "recording") {
 			const error = new Error("No active recording to stop");
 			this.trigger("error", error);

--- a/src/AuraliteSettingsTab.ts
+++ b/src/AuraliteSettingsTab.ts
@@ -27,6 +27,7 @@ export interface AuralitePluginSettings {
 	OPENAI_MODEL: OpenAIModel;
 	SILENCE_DETECTION_ENABLED: boolean;
 	SILENCE_DURATION: number;
+	SAVE_AUDIO_RECORDINGS: boolean;
 	DEFAULT_NOTE_TEMPLATE_PATH: string;
 	USE_EDIT_MODE_BY_DEFAULT: boolean;
 	TELEMETRY_ENABLED: boolean;
@@ -43,6 +44,7 @@ export const DEFAULT_SETTINGS: AuralitePluginSettings = {
 	OPENAI_MODEL: "gpt-4.1",
 	SILENCE_DETECTION_ENABLED: false,
 	SILENCE_DURATION: 2000,
+	SAVE_AUDIO_RECORDINGS: false,
 	DEFAULT_NOTE_TEMPLATE_PATH: "",
 	USE_EDIT_MODE_BY_DEFAULT: false,
 	TELEMETRY_ENABLED: true,
@@ -99,6 +101,7 @@ export class AuraliteSettingsTab extends PluginSettingTab {
 			cls: "auralite-settings-section-description",
 		});
 		this.addSilenceDetectionSettings(silenceSection);
+		this.addSaveAudioRecordingsSetting(silenceSection);
 
 		// 4. Notes & Templates Section
 		const templateSection = containerEl.createDiv({
@@ -277,6 +280,22 @@ export class AuraliteSettingsTab extends PluginSettingTab {
 			text: "seconds",
 			cls: "setting-item-description",
 		});
+	}
+
+	addSaveAudioRecordingsSetting(containerEl: HTMLElement) {
+		new Setting(containerEl)
+			.setName("Save audio recordings")
+			.setDesc(
+				"Save each transcription recording as a vault attachment and embed it after the transcript.",
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.SAVE_AUDIO_RECORDINGS)
+					.onChange(async (value) => {
+						this.plugin.settings.SAVE_AUDIO_RECORDINGS = value;
+						await this.plugin.saveSettings();
+					}),
+			);
 	}
 
 	addDefaultNoteTemplateSetting(containerEl: HTMLElement) {

--- a/src/ContextBuilder.ts
+++ b/src/ContextBuilder.ts
@@ -10,7 +10,11 @@ async function getActiveFileFormatted(plugin: AuralitePlugin) {
 		return undefined;
 	}
 
-	return { name: file.name, content: await plugin.app.vault.cachedRead(file) };
+	return {
+		name: file.name,
+		path: file.path,
+		content: await plugin.app.vault.cachedRead(file),
+	};
 }
 
 export class ContextBuilder {
@@ -28,7 +32,8 @@ export class ContextBuilder {
 			cursor: cursor,
 			activeEditor: activeView?.editor,
 			currentFile: await getActiveFileFormatted(this.plugin),
-			currentLine: line ? activeView?.editor.getLine(line) : undefined,
+			currentLine:
+				line !== undefined ? activeView?.editor.getLine(line) : undefined,
 			currentSelection: currentSelection ? currentSelection : undefined,
 		};
 	}

--- a/src/actions/Action.ts
+++ b/src/actions/Action.ts
@@ -21,6 +21,7 @@ export type EditorState = {
 	currentLine: string;
 	currentFile: {
 		name: string;
+		path: string;
 		content: string;
 	};
 };

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1,3 +1,4 @@
+import type { AudioRecording } from "@/AudioRecorder";
 import type { EditorState } from "@/actions/Action";
 import type AuralitePlugin from "@/main";
 import { removeWhitespace } from "@/utils";
@@ -47,10 +48,7 @@ export class AIManager extends TypedEvents<AIManagerEvents> {
 		return this.instructorClient;
 	}
 
-	async transcribeAudio(audioData: {
-		buffer: ArrayBuffer;
-		mimeType: string;
-	}): Promise<string> {
+	async transcribeAudio(audioData: AudioRecording): Promise<string> {
 		this.abortController = new AbortController();
 
 		// Use the selected transcription model from settings
@@ -60,7 +58,10 @@ export class AIManager extends TypedEvents<AIManagerEvents> {
 		try {
 			const response = await this.oai.audio.transcriptions.create(
 				{
-					file: new File([audioData.buffer], `audio.${audioData.mimeType}`),
+					file: new File(
+						[audioData.buffer],
+						`audio.${audioData.fileExtension}`,
+					),
 					model,
 				},
 				{ signal: this.abortController.signal },

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { Plugin, TFile } from "obsidian";
 import type { App } from "obsidian";
 import OpenAI from "openai";
 import { AudioRecorder } from "./AudioRecorder";
+import type { AudioRecording } from "./AudioRecorder";
 import {
 	type AuralitePluginSettings,
 	AuraliteSettingsTab,
@@ -24,6 +25,7 @@ import { WriteAction } from "./actions/WriteAction";
 import { AIManager } from "./ai";
 import { registerCommands } from "./commands";
 import { logger } from "./logging";
+import { createRecordingFilename } from "./recordings";
 import { AssistantTask } from "./tasks/AssistantTask";
 import { TranscribeTask } from "./tasks/TranscribeTask";
 import { telemetry } from "./telemetry";
@@ -202,6 +204,25 @@ export default class AuralitePlugin extends Plugin {
 		} catch (error) {
 			logger.error("Error saving transcription", { error });
 		}
+	}
+
+	async saveAudioRecording(
+		recording: AudioRecording,
+		sourcePath: string,
+	): Promise<string> {
+		const filename = createRecordingFilename(recording, new Date());
+		const attachmentPath =
+			await this.app.fileManager.getAvailablePathForAttachment(
+				filename,
+				sourcePath,
+			);
+		const file = await this.app.vault.createBinary(
+			attachmentPath,
+			recording.buffer,
+		);
+		const link = this.app.fileManager.generateMarkdownLink(file, sourcePath);
+
+		return `!${link}`;
 	}
 
 	private async saveTranscription(filePath: string, transcription: string) {

--- a/src/recordings.ts
+++ b/src/recordings.ts
@@ -1,0 +1,34 @@
+import type { AudioRecording } from "./AudioRecorder";
+
+function pad(value: number): string {
+	return value.toString().padStart(2, "0");
+}
+
+export function createRecordingFilename(
+	recording: AudioRecording,
+	recordedAt: Date,
+): string {
+	const date = [
+		recordedAt.getFullYear(),
+		pad(recordedAt.getMonth() + 1),
+		pad(recordedAt.getDate()),
+	].join("-");
+	const time = [
+		pad(recordedAt.getHours()),
+		pad(recordedAt.getMinutes()),
+		pad(recordedAt.getSeconds()),
+	].join("-");
+
+	return `Auralite recording ${date} ${time}.${recording.fileExtension}`;
+}
+
+export function appendRecordingEmbed(
+	transcription: string,
+	recordingEmbed?: string,
+): string {
+	if (!recordingEmbed) {
+		return transcription;
+	}
+
+	return `${transcription.trimEnd()}\n\n${recordingEmbed}`;
+}

--- a/src/tasks/AssistantTask.ts
+++ b/src/tasks/AssistantTask.ts
@@ -1,3 +1,4 @@
+import type { AudioRecording } from "@/AudioRecorder";
 import type { EditorState } from "@/actions/Action";
 import { FloatingBar } from "@/components/FloatingBar";
 import { WaveformVisualizer } from "@/components/WaveformVisualizer";
@@ -9,7 +10,7 @@ declare const __IS_DEV__: boolean;
 
 export class AssistantTask extends Task {
 	private editorState: Partial<EditorState> | undefined;
-	private audioData: { buffer: ArrayBuffer; mimeType: string } | null = null;
+	private audioData: AudioRecording | null = null;
 	private floatingBar: FloatingBar | null = null;
 	private waveformVisualizer: WaveformVisualizer | null = null;
 
@@ -107,10 +108,7 @@ export class AssistantTask extends Task {
 		this.floatingBar.show();
 	}
 
-	protected async handleRecordingComplete(data: {
-		buffer: ArrayBuffer;
-		mimeType: string;
-	}) {
+	protected async handleRecordingComplete(data: AudioRecording) {
 		this.audioData = data;
 		this.editorState = await this.contextBuilder.captureEditorState();
 

--- a/src/tasks/TranscribeTask.ts
+++ b/src/tasks/TranscribeTask.ts
@@ -1,13 +1,14 @@
+import type { AudioRecording } from "@/AudioRecorder";
 import type { EditorState } from "@/actions/Action";
 import { FloatingBar } from "@/components/FloatingBar";
 import { WaveformVisualizer } from "@/components/WaveformVisualizer";
 import { logger } from "@/logging";
+import { appendRecordingEmbed } from "@/recordings";
 import { delay } from "@/utils";
 import { Task } from "./Task";
 
 export class TranscribeTask extends Task {
 	private editorState: Partial<EditorState> | undefined;
-	private audioData: { buffer: ArrayBuffer; mimeType: string } | null = null;
 	private floatingBar: FloatingBar | null = null;
 	private waveformVisualizer: WaveformVisualizer | null = null;
 
@@ -75,37 +76,38 @@ export class TranscribeTask extends Task {
 	}
 
 	protected async handleRecordingStopped() {
-		this.editorState = await this.contextBuilder.captureEditorState();
 		this.waveformVisualizer?.stop();
 		this.floatingBar?.setStatus("Finished recording");
 	}
 
-	protected async handleRecordingComplete(data: {
-		buffer: ArrayBuffer;
-		mimeType: string;
-	}) {
+	protected async handleRecordingComplete(recording: AudioRecording) {
 		try {
-			this.audioData = data;
+			this.editorState = await this.contextBuilder.captureEditorState();
+			if (!this.editorState.cursor || !this.editorState.activeEditor) {
+				throw new Error("No cursor or active editor found");
+			}
 
-			if (!this.editorState || !this.audioData) {
-				throw new Error("No editor state or audio data found");
+			let recordingEmbed: string | undefined;
+			if (this.plugin.settings.SAVE_AUDIO_RECORDINGS) {
+				const sourcePath = this.editorState.currentFile?.path;
+				if (!sourcePath) {
+					throw new Error("No active note found for recording attachment");
+				}
+				recordingEmbed = await this.plugin.saveAudioRecording(
+					recording,
+					sourcePath,
+				);
 			}
 
 			this.floatingBar?.setStatus("Transcribing...");
-			const transcription = await this.aiManager.transcribeAudio(
-				this.audioData,
+			const transcription = await this.aiManager.transcribeAudio(recording);
+			const content = appendRecordingEmbed(transcription, recordingEmbed);
+
+			this.editorState.activeEditor.replaceRange(
+				content,
+				this.editorState.cursor,
 			);
-
-			if (this.editorState.cursor && this.editorState.activeEditor) {
-				this.editorState.activeEditor.replaceRange(transcription, {
-					line: this.editorState.cursor?.line,
-					ch: this.editorState.cursor?.ch,
-				});
-
-				this.floatingBar?.setStatus("Added to editor");
-			} else {
-				this.floatingBar?.setStatus("No cursor or active editor found");
-			}
+			this.floatingBar?.setStatus("Added to editor");
 		} catch (error) {
 			logger.error("Error handling completed recording:", { error });
 			this.status = "error";

--- a/tests/recordings.test.ts
+++ b/tests/recordings.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import {
+	appendRecordingEmbed,
+	createRecordingFilename,
+} from "../src/recordings";
+
+describe("recording attachments", () => {
+	test("creates a filesystem-safe local timestamped filename", () => {
+		const recordedAt = new Date(2026, 6, 12, 9, 5, 3);
+
+		expect(
+			createRecordingFilename(
+				{ buffer: new ArrayBuffer(0), fileExtension: "webm" },
+				recordedAt,
+			),
+		).toBe("Auralite recording 2026-07-12 09-05-03.webm");
+	});
+
+	test("embeds a saved recording after the transcript", () => {
+		expect(appendRecordingEmbed("Spoken thought.\n", "![[recording.webm]]")).toBe(
+			"Spoken thought.\n\n![[recording.webm]]",
+		);
+	});
+
+	test("leaves the transcript unchanged when saving is disabled", () => {
+		expect(appendRecordingEmbed("Spoken thought.")).toBe("Spoken thought.");
+	});
+});


### PR DESCRIPTION
Add an opt-in setting that saves transcription recordings as vault attachments and embeds the resulting audio link after the transcript.

The recording is persisted before transcription through Obsidian's attachment APIs, so its location, collision handling, and generated Markdown link respect the user's vault preferences. Existing behavior remains unchanged because saving defaults to off.

This also makes recording completion a single ordered pipeline. Editor state is captured when the completed recording is handled, removing the prior race between the separate stopped and completed events. The audio payload now names its file extension accurately instead of exposing it as a MIME type.

Verified with type checking, Biome, focused unit tests, a production build, and a live Obsidian dev-vault run that confirmed exact binary persistence, transcript insertion, audio embedding, cleanup, and no runtime errors.

Fixes #3
