### PR TITLE
fix: harden recording attachments and release assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format": "biome format src version-bump.ts --write",
     "check": "biome check --write src version-bump.ts && bun run type-check",
     "type-check": "bun tsc --noEmit",
-    "version": "bun ./version-bump.ts && git add manifest.json versions.json",
+    "version": "bun ./version-bump.ts && bun run build && git add manifest.json versions.json",
     "semantic-release": "semantic-release"
   },
   "type": "commonjs",

--- a/src/main.ts
+++ b/src/main.ts
@@ -208,7 +208,7 @@ export default class AuralitePlugin extends Plugin {
 
 	async saveAudioRecording(
 		recording: AudioRecording,
-		sourcePath: string,
+		sourcePath?: string,
 	): Promise<string> {
 		const filename = createRecordingFilename(recording, new Date());
 		const attachmentPath =
@@ -220,7 +220,10 @@ export default class AuralitePlugin extends Plugin {
 			attachmentPath,
 			recording.buffer,
 		);
-		const link = this.app.fileManager.generateMarkdownLink(file, sourcePath);
+		const link = this.app.fileManager.generateMarkdownLink(
+			file,
+			sourcePath ?? "",
+		);
 
 		return `!${link}`;
 	}

--- a/src/tasks/TranscribeTask.ts
+++ b/src/tasks/TranscribeTask.ts
@@ -89,13 +89,9 @@ export class TranscribeTask extends Task {
 
 			let recordingEmbed: string | undefined;
 			if (this.plugin.settings.SAVE_AUDIO_RECORDINGS) {
-				const sourcePath = this.editorState.currentFile?.path;
-				if (!sourcePath) {
-					throw new Error("No active note found for recording attachment");
-				}
 				recordingEmbed = await this.plugin.saveAudioRecording(
 					recording,
-					sourcePath,
+					this.editorState.currentFile?.path,
 				);
 			}
 


### PR DESCRIPTION
Address the actionable review feedback from #11 without weakening the recording-backup guarantee. Recording persistence now accepts an optional note path, allowing Obsidian to choose its fallback attachment location while still inserting the generated embed into the editor.

Also rebuild release assets during the version lifecycle, after semantic-release updates the manifests. Version 1.6.0 exposed the ordering bug by publishing a `manifest.json` asset that still declared 1.5.0 even though the tagged source manifest was correct.

The no-path flow was verified in a live Obsidian dev vault: the binary attachment was created, the transcript and embed were inserted, the task finished, cleanup succeeded, and no runtime errors were captured. The exact `npm version` lifecycle now rebuilds `out/manifest.json` with the current package version. Type checking, Biome, unit tests, and the production build pass.

Refs #11
